### PR TITLE
Redial API for reconnects

### DIFF
--- a/Robust.LoaderApi/IRedialApi.cs
+++ b/Robust.LoaderApi/IRedialApi.cs
@@ -17,6 +17,7 @@ namespace Robust.LoaderApi
         ///     *It is expected that the engine use the --ss14-address parameter for redialling to the same server.*
         /// </summary>
         /// <param name="uri">The server Uri, such as "ss14://localhost:1212/".</param>
-        void Redial(Uri uri);
+        /// <param name="text">Informational text on the cause of the reconnect. Empty gives a default reason.</param>
+        void Redial(Uri uri, string text = "");
     }
 }

--- a/Robust.LoaderApi/IRedialApi.cs
+++ b/Robust.LoaderApi/IRedialApi.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Robust.LoaderApi
+{
+    /// <summary>
+    ///     API that the engine can use to invoke the launcher (if supported)
+    /// </summary>
+    public interface IRedialApi
+    {
+        /// <summary>
+        ///     Try to cause the launcher to either reconnect to the same server or connect to a new server.
+        ///     *The engine should shutdown on success, and this should be enforced in RobustToolbox.*
+        ///     Will throw an exception if contacting the launcher failed (success indicates it is now the launcher's responsibility).
+        ///     *It is expected that the engine use the --ss14-address parameter for redialling to the same server.*
+        /// </summary>
+        /// <param name="uri">The server Uri, such as "ss14://localhost:1212/".</param>
+        void Redial(Uri uri);
+    }
+}

--- a/Robust.LoaderApi/LoadMainArgs.cs
+++ b/Robust.LoaderApi/LoadMainArgs.cs
@@ -14,5 +14,10 @@ namespace Robust.LoaderApi
         ///     File API usable to read files from the engine's installation directory.
         /// </summary>
         IFileApi FileApi { get; }
+
+        /// <summary>
+        ///     Redialling API usable to cause a connection to a new (or the same) server. Only provided if supported.
+        /// </summary>
+        IRedialApi? RedialApi => null;
     }
 }


### PR DESCRIPTION
Presently theoretical, but design work has been done, and this is the key shared-code bit between RT and Launcher repositories.
